### PR TITLE
github.com/cockroachdb/errorsを使う

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 
 	"hato-bot-go/lib/amesh"
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cockroachdb/errors v1.12.0
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/pkg/errors v0.9.1
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792
 )
 
@@ -33,6 +32,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.8.0 // indirect


### PR DESCRIPTION
`github.com/pkg/errors` を使っている箇所があったので `github.com/cockroachdb/errors` を使うようにします。