### PR TITLE
fix: deferのClose失敗時に元のエラーを上書きしないよう修正

### DIFF
--- a/cmd/mixi2_bot/main.go
+++ b/cmd/mixi2_bot/main.go
@@ -53,7 +53,7 @@ func run() (err error) {
 	}
 	defer func(streamConn *grpc.ClientConn) {
 		if closeErr := streamConn.Close(); closeErr != nil {
-			err = errors.Wrap(err, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(streamConn)
 
@@ -64,7 +64,7 @@ func run() (err error) {
 	}
 	defer func(apiConn *grpc.ClientConn) {
 		if closeErr := apiConn.Close(); closeErr != nil {
-			err = errors.Wrap(err, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(apiConn)
 

--- a/lib/amesh/amesh.go
+++ b/lib/amesh/amesh.go
@@ -396,7 +396,7 @@ func executeAndReadResponse(client *http.Client, req *http.Request) (body []byte
 
 	defer func(readCloser io.ReadCloser) {
 		if closeErr := readCloser.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 
@@ -644,7 +644,7 @@ func downloadTile(ctx context.Context, client *http.Client, tileURL string) (img
 	}
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 
@@ -776,7 +776,7 @@ func getLatestTimestamps(ctx context.Context, client *http.Client) map[string]st
 func handleHTTPResponse(resp *http.Response) (body []byte, err error) {
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 

--- a/lib/misskey/bot.go
+++ b/lib/misskey/bot.go
@@ -67,7 +67,7 @@ func (bot *Bot) CreateNote(ctx context.Context, params *CreateNoteParams) (err e
 	}
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 	// jscpd:ignore-end
@@ -89,7 +89,7 @@ func (bot *Bot) UploadFile(ctx context.Context, reader io.Reader, fileName strin
 	writer := multipart.NewWriter(&buf)
 	defer func(writer *multipart.Writer) {
 		if closeErr := writer.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(writer)
 
@@ -126,7 +126,7 @@ func (bot *Bot) UploadFile(ctx context.Context, reader io.Reader, fileName strin
 	}
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 
@@ -152,7 +152,7 @@ func (bot *Bot) AddReaction(ctx context.Context, noteID, reaction string) (err e
 	}
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 	// jscpd:ignore-end

--- a/lib/mixi2/handler.go
+++ b/lib/mixi2/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) uploadMedia(ctx context.Context, uploadURL string, buffer *byt
 	}
 	defer func(body io.ReadCloser) {
 		if closeErr := body.Close(); closeErr != nil {
-			err = errors.Wrap(closeErr, "Failed to Close")
+			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
 


### PR DESCRIPTION
`errors.Wrap(closeErr, ...)` の代わりに `errors.Join(err, errors.Wrap(closeErr, ...))` を使用し、 既存のエラーと `Close` エラーを両方保持するよう修正します。