### PR TITLE
CI pr-super-lint: PRへの書き込み権限付与

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot-go/actions/runs/24282956108/job/70907615602#step:7:556

```
2026-04-11 13:01:24 [WARN]   Failed to call GitHub API (https://api.github.com/repos/dev-hato/hato-bot-go/issues/360/comments): curl: (22) The requested URL returned error: 403
```

上記Warningを解消するため、CI `pr-super-lint` に `pull-requests: write` を付与します。