### PR TITLE
refactor:パッケージ名と混同しないよう変数filePathを改名する

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -66,10 +66,10 @@ func main() {
 
 		// ファイル名を生成
 		fileName := amesh.GenerateFileName(location)
-		filePath := filepath.Clean(filepath.Join(".", fileName))
+		cleanedFilePath := filepath.Clean(filepath.Join(".", fileName))
 
 		// ファイルに保存
-		file, err := os.Create(filePath)
+		file, err := os.Create(cleanedFilePath)
 		if err != nil {
 			panic(errors.Wrap(err, "Failed to os.Create"))
 		}
@@ -83,7 +83,7 @@ func main() {
 			panic(errors.Wrap(err, "Failed to io.Copy"))
 		}
 
-		fmt.Printf("Amesh image saved to %s\n", filePath)
+		fmt.Printf("Amesh image saved to %s\n", cleanedFilePath)
 	default:
 		panic(errors.Errorf("Unknown command: %s", command))
 	}


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot-go/pull/360#discussion_r3067969574

パッケージ `filepath` と紛らわしいので、変数 `filePath` を改名します。