### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          permission-organization-projects: write
+          permission-pull-requests: read
       - uses: dev-hato/actions-add-to-projects@f807db51e3f02f481e24c630e6a39f6e54939a04 # v1.0.7
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' || github.repository == github.event.pull_request.head.repo.full_name
     steps:
+      # jscpd:ignore-start
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -21,6 +22,7 @@ jobs:
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
           permission-organization-projects: write
           permission-pull-requests: read
+      # jscpd:ignore-end
       - uses: dev-hato/actions-add-to-projects@f807db51e3f02f481e24c630e6a39f6e54939a04 # v1.0.7
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    # jscpd:ignore-start
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -35,6 +36,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: fix-go-version
           pr-title-prefix: Goのバージョンを直してあげたよ！
+          # jscpd:ignore-end
   build_docker_image:
     runs-on: ubuntu-latest
     env:
@@ -144,6 +146,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: npm
           pr-title-prefix: package.jsonやpackage-lock.jsonが更新されたので直してあげたよ！
+  # jscpd:ignore-start
   update-dockle:
     runs-on: ubuntu-latest
     steps:
@@ -156,6 +159,7 @@ jobs:
       - uses: dev-hato/actions-update-dockle@5f29c585fb09cabc7c94bd353a3ad6fbeae17c51 # v0.0.141
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+          # jscpd:ignore-end
   dockle:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
       - uses: dev-hato/actions-format-json-yml@251638e8f9b506b75637531801c20baec9077ec5 # v0.0.103
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -16,6 +16,7 @@ permissions:
   contents: write
   pull-requests: write
 jobs:
+  # jscpd:ignore-start
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
@@ -34,6 +35,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-workflows: write
+      # jscpd:ignore-end
       - uses: dev-hato/actions-format-json-yml@251638e8f9b506b75637531801c20baec9077ec5 # v0.0.103
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -32,19 +32,13 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           go-version-file: go.mod
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
       # formatする
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/format.sh"
       - uses: dev-hato/actions-diff-pr-management@5cd3792bc98beed11cda90898bc81af6bfa199af # v2.2.5
         if: success() || failure()
         with:
-          github-token: ${{steps.generate_token.outputs.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: fix-format
           pr-title-prefix: formatが間違ってたので直してあげたよ！
 concurrency:

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -19,6 +19,7 @@ permissions:
   pull-requests: write
 jobs:
   # PRが来たらformatをかけてみて、差分があればPRを作って、エラーで落ちるjob
+  # jscpd:ignore-start
   pr-format:
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +33,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           go-version-file: go.mod
+      # jscpd:ignore-end
       # formatする
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/format.sh"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -39,7 +39,7 @@ jobs:
           cache: npm
           node-version-file: package.json
       - run: bash "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/npm_ci.sh"
-      - uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+      - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           LINTER_RULES_PATH: .
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,6 +1,6 @@
 {
   "threshold": 0,
   "reporters": ["consoleFull"],
-  "ignore": ["**/__snapshots__/**", "**/node_modules/**", "**/mock_*.go"],
+  "ignore": ["**/__snapshots__/**", "**/node_modules/**", "**/mock_*.go", "**/package.json", "**/package-lock.json"],
   "absolute": true
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,6 +1,12 @@
 {
   "threshold": 0,
   "reporters": ["consoleFull"],
-  "ignore": ["**/__snapshots__/**", "**/node_modules/**", "**/mock_*.go", "**/package.json", "**/package-lock.json"],
+  "ignore": [
+    "**/__snapshots__/**",
+    "**/node_modules/**",
+    "**/mock_*.go",
+    "**/package.json",
+    "**/package-lock.json"
+  ],
   "absolute": true
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-bookworm@sha256:ab3d6955bbc813a0f3fdf220c1d817dd89c0b3f283777db8ece4a32fe7858edd AS builder
+FROM golang:1.26.4-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ docker compose -f docker-compose.yml -f dev.docker-compose.yml up --build
 
 **Webメルカトル投影 (`getWebMercatorPixel`)**
 
+<!-- jscpd:ignore-start -->
+
 ```go
 zoomFactor := float64(int(1) << uint(params.Zoom))
 x := 256.0 * zoomFactor * (params.Lng + 180) / 360.0
@@ -258,6 +260,8 @@ draw.DrawMask(img, destRect, radarTile, image.Point{},
     image.NewUniform(color.RGBA{R: 255, G: 255, B: 255, A: 128}),
     image.Point{}, draw.Over)
 ```
+
+<!-- jscpd:ignore-end -->
 
 #### 3. 距離円描画アルゴリズム
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hato-bot-go
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/lib/amesh/amesh.go
+++ b/lib/amesh/amesh.go
@@ -489,10 +489,13 @@ func getWebMercatorPixel(params *CreateAmeshImageParams) (float64, float64) {
 	if params.Zoom < 0 || 30 < params.Zoom {
 		return 0, 0
 	}
+
+	// jscpd:ignore-start
 	zoomFactor := float64(int(1) << uint(params.Zoom))
 	x := 256.0 * zoomFactor * (params.Lng + 180) / 360.0
 	y := 256.0 * zoomFactor * (0.5 - math.Log(math.Tan(math.Pi/4+deg2rad(params.Lat)/2))/(2.0*math.Pi))
 	return x, y
+	// jscpd:ignore-end
 }
 
 // drawLightningMarker 画像上に落雷マーカーを描画する
@@ -638,6 +641,7 @@ func downloadTile(ctx context.Context, client *http.Client, tileURL string) (img
 		return nil, errors.Wrap(err, "Failed to http.NewRequestWithContext")
 	}
 
+	// jscpd:ignore-start
 	resp, err := httpclient.ExecuteHTTPRequest(client, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to ExecuteHTTPRequest")
@@ -647,6 +651,7 @@ func downloadTile(ctx context.Context, client *http.Client, tileURL string) (img
 			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
+	// jscpd:ignore-end
 
 	img, _, err = image.Decode(resp.Body)
 	if err != nil {

--- a/lib/amesh/amesh_test.go
+++ b/lib/amesh/amesh_test.go
@@ -103,6 +103,7 @@ func TestCreateAmeshImage(t *testing.T) {
 			expectedImageSize: 768,
 			expectError:       nil,
 		},
+		// jscpd:ignore-start
 		{
 			name: "空のタイムスタンプ結果",
 			params: &amesh.CreateAmeshImageParams{
@@ -188,6 +189,7 @@ func TestCreateAmeshImage(t *testing.T) {
 			expectedImageSize: 768,
 			expectError:       nil,
 		},
+		// jscpd:ignore-end
 		{
 			name: "小さなタイル数でのテスト",
 			params: &amesh.CreateAmeshImageParams{
@@ -323,6 +325,7 @@ func TestCreateImageBufferWithClient(t *testing.T) {
 			},
 			expectError: lib.ErrParamsNil,
 		},
+		// jscpd:ignore-start
 		{
 			name: "nilロケーション",
 			params: &amesh.CreateImageBufferWithClientParams{
@@ -364,6 +367,7 @@ func TestCreateImageBufferWithClient(t *testing.T) {
 			}
 		})
 	}
+	// jscpd:ignore-end
 }
 
 // TestParseLocationWithClient ParseLocationWithClient関数をモックHTTPクライアントでテストする
@@ -586,6 +590,7 @@ func TestParseLocationWithClient(t *testing.T) {
 			params:      nil,
 			expectError: lib.ErrParamsNil,
 		},
+		// jscpd:ignore-start
 		{
 			name: "nilクライアント",
 			params: &amesh.ParseLocationWithClientParams{
@@ -612,6 +617,7 @@ func TestParseLocationWithClient(t *testing.T) {
 			}
 		})
 	}
+	// jscpd:ignore-end
 }
 
 // TestGenerateFileName GenerateFileName関数をテストする

--- a/lib/amesh/amesh_test.go
+++ b/lib/amesh/amesh_test.go
@@ -51,6 +51,14 @@ func (f roundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // TestCreateAmeshImage CreateAmeshImage関数をテストする
 func TestCreateAmeshImage(t *testing.T) {
+	timestampsResponse := `[
+				{
+					"basetime": "20240101120000",
+					"validtime": "20240101120000", 
+					"elements": ["hrpns_nd", "liden"]
+				}
+			]`
+
 	dummyTileBytes, err := createDummyPNGBytes(
 		256,
 		256,
@@ -71,13 +79,7 @@ func TestCreateAmeshImage(t *testing.T) {
 			name: "成功した画像作成",
 			params: &amesh.CreateAmeshImageParams{
 				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
+					TimestampsResponse: timestampsResponse,
 					LightningResponse: `{
 				"features": [
 					{
@@ -122,15 +124,9 @@ func TestCreateAmeshImage(t *testing.T) {
 			name: "タイルダウンロード失敗を適切に処理",
 			params: &amesh.CreateAmeshImageParams{
 				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
-					LightningResponse: `{"features": []}`,
-					DummyTileBytes:    dummyTileBytes,
+					TimestampsResponse: timestampsResponse,
+					LightningResponse:  `{"features": []}`,
+					DummyTileBytes:     dummyTileBytes,
 				}),
 				Lat:         35.6895,
 				Lng:         139.6917,
@@ -179,15 +175,9 @@ func TestCreateAmeshImage(t *testing.T) {
 			name: "落雷データJSONエラー",
 			params: &amesh.CreateAmeshImageParams{
 				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
-					LightningResponse: `invalid json`,
-					DummyTileBytes:    dummyTileBytes,
+					TimestampsResponse: timestampsResponse,
+					LightningResponse:  `invalid json`,
+					DummyTileBytes:     dummyTileBytes,
 				}),
 				Lat:         35.6895,
 				Lng:         139.6917,
@@ -202,13 +192,7 @@ func TestCreateAmeshImage(t *testing.T) {
 			name: "小さなタイル数でのテスト",
 			params: &amesh.CreateAmeshImageParams{
 				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
+					TimestampsResponse: timestampsResponse,
 					LightningResponse: `{
 				"features": [
 					{
@@ -293,6 +277,18 @@ func TestCreateImageBufferWithClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	client := createConfigurableMockHTTPClient(httpMockConfig{
+		TimestampsResponse: `[
+				{
+					"basetime": "20240101120000",
+					"validtime": "20240101120000", 
+					"elements": ["hrpns_nd", "liden"]
+				}
+			]`,
+		LightningResponse: `{"features": []}`,
+		DummyTileBytes:    dummyTileBytes,
+	})
+
 	tests := []struct {
 		name        string
 		params      *amesh.CreateImageBufferWithClientParams
@@ -301,17 +297,7 @@ func TestCreateImageBufferWithClient(t *testing.T) {
 		{
 			name: "成功したbytes.Buffer作成",
 			params: &amesh.CreateImageBufferWithClientParams{
-				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
-					LightningResponse: `{"features": []}`,
-					DummyTileBytes:    dummyTileBytes,
-				}),
+				Client: client,
 				Location: &amesh.Location{
 					Lat:       35.6895,
 					Lng:       139.6917,
@@ -340,17 +326,7 @@ func TestCreateImageBufferWithClient(t *testing.T) {
 		{
 			name: "nilロケーション",
 			params: &amesh.CreateImageBufferWithClientParams{
-				Client: createConfigurableMockHTTPClient(httpMockConfig{
-					TimestampsResponse: `[
-				{
-					"basetime": "20240101120000",
-					"validtime": "20240101120000", 
-					"elements": ["hrpns_nd", "liden"]
-				}
-			]`,
-					LightningResponse: `{"features": []}`,
-					DummyTileBytes:    dummyTileBytes,
-				}),
+				Client:   client,
 				Location: nil,
 			},
 			expectError: lib.ErrParamsNil,

--- a/lib/misskey/bot.go
+++ b/lib/misskey/bot.go
@@ -120,6 +120,7 @@ func (bot *Bot) UploadFile(ctx context.Context, reader io.Reader, fileName strin
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
+	// jscpd:ignore-start
 	resp, err := httpclient.ExecuteHTTPRequest(bot.BotSetting.Client, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to executeHTTPRequest")
@@ -129,6 +130,7 @@ func (bot *Bot) UploadFile(ctx context.Context, reader io.Reader, fileName strin
 			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
+	// jscpd:ignore-end
 
 	var uploadedFile File
 	if err = json.NewDecoder(resp.Body).Decode(&uploadedFile); err != nil {

--- a/lib/mixi2/handler.go
+++ b/lib/mixi2/handler.go
@@ -78,6 +78,7 @@ func (h *Handler) uploadMedia(ctx context.Context, uploadURL string, buffer *byt
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	// タイムアウト付きでアップロードを実行
+	// jscpd:ignore-start
 	resp, err := httpclient.ExecuteHTTPRequest(&http.Client{Timeout: 30 * time.Second}, req)
 	if err != nil {
 		return errors.Wrap(err, "Failed to httpclient.ExecuteHTTPRequest")
@@ -87,6 +88,7 @@ func (h *Handler) uploadMedia(ctx context.Context, uploadURL string, buffer *byt
 			err = errors.Join(err, errors.Wrap(closeErr, "Failed to Close"))
 		}
 	}(resp.Body)
+	// jscpd:ignore-end
 
 	return nil
 }


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot-go/pull/439 をベースにsuper-linterをアップデートします。
CI `pr-format` ではApp tokenを取得する必要がないので、デフォルトのtokenを使うようにしています。